### PR TITLE
Change logs conf

### DIFF
--- a/conf/log/intake.conf
+++ b/conf/log/intake.conf
@@ -1,0 +1,38 @@
+{
+    "handlers": {
+        "errors": {
+            "backupCount": 90,
+            "when":"midnight",
+            "level": "ERROR",
+            "formatter": "detailed",
+            "class": "logging.handlers.TimedRotatingFileHandler",
+            "filename": "/var/log/emission/pipeline/intake-errors.log"
+        },
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "WARNING"
+        },
+        "file": {
+            "backupCount": 90,
+            "filename": "/var/log/emission/pipeline/intake.log",
+            "when":"midnight",
+            "formatter": "detailed",
+            "class": "logging.handlers.TimedRotatingFileHandler"
+        }
+    },
+    "version": 1,
+    "root": {
+        "handlers": [
+            "console",
+            "file",
+            "errors"
+        ],
+        "level": "DEBUG"
+    },
+    "formatters": {
+        "detailed": {
+            "class": "logging.Formatter",
+            "format": "%(asctime)s:%(levelname)s:%(thread)d:%(message)s"
+        }
+    }
+}

--- a/conf/log/webserver.conf
+++ b/conf/log/webserver.conf
@@ -1,0 +1,38 @@
+{
+    "handlers": {
+        "errors": {
+            "backupCount": 90,
+            "when":"midnight",
+            "level": "ERROR",
+            "formatter": "detailed",
+            "class": "logging.handlers.TimedRotatingFileHandler",
+            "filename": "/var/log/emission/webserver/webserver-errors.log"
+        },
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "WARNING"
+        },
+        "file": {
+            "backupCount": 90,
+            "filename": "/var/log/emission/webserver/webserver.log",
+            "when":"midnight",
+            "formatter": "detailed",
+            "class": "logging.handlers.TimedRotatingFileHandler"
+        }
+    },
+    "version": 1,
+    "root": {
+        "handlers": [
+            "console",
+            "file",
+            "errors"
+        ],
+        "level": "DEBUG"
+    },
+    "formatters": {
+        "detailed": {
+            "class": "logging.Formatter",
+            "format": "%(asctime)s:%(levelname)s:%(thread)d:%(message)s"
+        }
+    }
+}


### PR DESCRIPTION
I added a different configuration than the basic configuration of e-mission-server into `intake.conf` and `webserver.conf`.

We will now use a `TimedRotatingFileHandler` and rotate at midnight. I will then use a local script to merge the differents `intake_<thread>.log` into one.